### PR TITLE
Fix usages of implicit optional types

### DIFF
--- a/httpx_caching/_async/_transport.py
+++ b/httpx_caching/_async/_transport.py
@@ -19,9 +19,9 @@ class AsyncCachingTransport(httpx.AsyncBaseTransport):
     def __init__(
         self,
         transport: httpx.AsyncBaseTransport,
-        cache: AsyncDictCache = None,
+        cache: Optional[AsyncDictCache] = None,
         cache_etags: bool = True,
-        heuristic: BaseHeuristic = None,
+        heuristic: Optional[BaseHeuristic] = None,
         cacheable_methods: Iterable[str] = ("GET",),
         cacheable_status_codes: Iterable[int] = (
             200,

--- a/httpx_caching/_sync/_transport.py
+++ b/httpx_caching/_sync/_transport.py
@@ -19,9 +19,9 @@ class SyncCachingTransport(httpx.BaseTransport):
     def __init__(
         self,
         transport: httpx.BaseTransport,
-        cache: SyncDictCache = None,
+        cache: Optional[SyncDictCache] = None,
         cache_etags: bool = True,
-        heuristic: BaseHeuristic = None,
+        heuristic: Optional[BaseHeuristic] = None,
         cacheable_methods: Iterable[str] = ("GET",),
         cacheable_status_codes: Iterable[int] = (
             200,


### PR DESCRIPTION
If the default value of an argument is `None`, the type should be `Optional[...]`. Fixed with the [no_implicit_optional](https://github.com/hauntsaninja/no_implicit_optional) codemod.